### PR TITLE
Support AWS Config logs S3 retention limit

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,6 +25,9 @@ terraform {
 }
 
 data "aws_caller_identity" "current" {}
+data "aws_iam_session_context" "current" {
+  arn = data.aws_caller_identity.current.arn
+}
 
 locals {
   is_individual_account = var.account_type == "individual"

--- a/resources/config_recorder.py
+++ b/resources/config_recorder.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python3
+
+import boto3
+import os
+
+frequency = os.environ["CONFIG_RECORDER_FREQUENCY"]
+retention = int(os.getenv("CONFIG_RECORDER_RETENTION", "0"))
+role_arn = os.environ["TF_AWS_ROLE"]
+target_regions = os.environ["CONFIG_REGIONS"].split(",")
+
+# assume terraform role
+sts_client = boto3.client("sts")
+print(f"Assuming AWS role {role_arn}")
+assumed = sts_client.assume_role(
+    RoleArn=role_arn,
+    RoleSessionName="TerragruntConfigurationRecorderProvisioner",
+)["Credentials"]
+
+for region in target_regions:
+    # setup AWS Config connection
+    config = boto3.client(
+        "config",
+        aws_access_key_id=assumed["AccessKeyId"],
+        aws_secret_access_key=assumed["SecretAccessKey"],
+        aws_session_token=assumed["SessionToken"],
+        region_name=region,
+    )
+
+    recorder = config.describe_configuration_recorders()["ConfigurationRecorders"][0]
+    recordingMode = recorder.get("recordingMode", {})
+    if recordingMode.get("recordingFrequency") != frequency:
+        print(f"Setting {region} Config recorder frequency to {frequency}")
+        recordingMode["recordingFrequency"] = frequency
+        recorder["recordingMode"] = recordingMode
+        config.put_configuration_recorder(ConfigurationRecorder=recorder)
+
+    if retention:
+        current_retention = config.describe_retention_configurations()[
+            "RetentionConfigurations"
+        ]
+        if current_retention != [
+            {"Name": recorder["name"], "RetentionPeriodInDays": retention}
+        ]:
+            print(f"Setting {region} Config retention to {retention} days")
+            config.put_retention_configuration(RetentionPeriodInDays=retention)

--- a/variables.tf
+++ b/variables.tf
@@ -289,6 +289,24 @@ variable "config_s3_bucket_key_prefix" {
   default     = "config"
 }
 
+variable "config_tuning_enabled" {
+  description = "Tune AWS Config frequency & retention using Python local provisioner."
+  type        = bool
+  default     = false
+}
+
+variable "config_retention_days" {
+  description = "AWS Config retention in days. 0 disables setting retention."
+  type        = number
+  default     = 0
+}
+
+variable "config_continuous_recording" {
+  description = "Enable CONTINUOUS Config recorder mode (as opposed to DAILY)"
+  type        = bool
+  default     = true
+}
+
 variable "config_sns_topic_name" {
   description = "The name of the SNS Topic to be used to notify configuration changes."
   type        = string


### PR DESCRIPTION
Enable expiring specifically the `config/` path in the audit log bucket.