### PR TITLE
Support per-region Config frequency

### DIFF
--- a/config_baselines.tf
+++ b/config_baselines.tf
@@ -685,8 +685,9 @@ resource "terraform_data" "recorder_tuning" {
     module.config_baseline_us-west-2[*].configuration_recorder,
     [
       var.config_continuous_recording,
-      var.config_retention_days
+      var.config_retention_days,
     ],
+    var.config_continuous_recording_regions,
   )
 
   provisioner "local-exec" {
@@ -694,6 +695,7 @@ resource "terraform_data" "recorder_tuning" {
     interpreter = ["python3"]
     environment = {
       CONFIG_RECORDER_FREQUENCY = var.config_continuous_recording ? "CONTINUOUS" : "DAILY"
+      CONFIG_CONTINUOUS_REGIONS = join(",", var.config_continuous_recording_regions)
       CONFIG_RECORDER_RETENTION = var.config_retention_days
       CONFIG_REGIONS            = join(",", var.target_regions)
       TF_AWS_ROLE               = data.aws_iam_session_context.current.issuer_arn

--- a/variables.tf
+++ b/variables.tf
@@ -313,6 +313,12 @@ variable "config_continuous_recording" {
   default     = true
 }
 
+variable "config_continuous_recording_regions" {
+  description = "Limit CONTINUOUS Config recording to these regions (ALL regions if empty)"
+  type        = list(string)
+  default     = []
+}
+
 variable "config_sns_topic_name" {
   description = "The name of the SNS Topic to be used to notify configuration changes."
   type        = string


### PR DESCRIPTION
This will help optimise costs by only limiting continuous Config recording to selected regions.

The default behaviour is backwards compatible; if no regions are selected, all the target regions are configured to the same config frequency.