### PR TITLE
Support limiting Config recorder resource types

### DIFF
--- a/config_baselines.tf
+++ b/config_baselines.tf
@@ -116,6 +116,7 @@ module "config_baseline_ap-northeast-1" {
   sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-northeast-1"
   continuous_recording          = var.config_continuous_recording ? contains(var.config_continuous_recording_regions, "ap-northeast-1") : false
+  limit_resource_types          = var.config_limit_resource_types
 
   tags = var.tags
 
@@ -138,6 +139,7 @@ module "config_baseline_ap-northeast-2" {
   sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-northeast-2"
   continuous_recording          = var.config_continuous_recording ? contains(var.config_continuous_recording_regions, "ap-northeast-2") : false
+  limit_resource_types          = var.config_limit_resource_types
 
   tags = var.tags
 
@@ -160,6 +162,7 @@ module "config_baseline_ap-northeast-3" {
   sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-northeast-3"
   continuous_recording          = var.config_continuous_recording ? contains(var.config_continuous_recording_regions, "ap-northeast-3") : false
+  limit_resource_types          = var.config_limit_resource_types
 
   tags = var.tags
 
@@ -182,6 +185,7 @@ module "config_baseline_ap-south-1" {
   sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-south-1"
   continuous_recording          = var.config_continuous_recording ? contains(var.config_continuous_recording_regions, "ap-south-1") : false
+  limit_resource_types          = var.config_limit_resource_types
 
   tags = var.tags
 
@@ -204,6 +208,7 @@ module "config_baseline_ap-southeast-1" {
   sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-southeast-1"
   continuous_recording          = var.config_continuous_recording ? contains(var.config_continuous_recording_regions, "ap-southeast-1") : false
+  limit_resource_types          = var.config_limit_resource_types
 
   tags = var.tags
 
@@ -226,6 +231,7 @@ module "config_baseline_ap-southeast-2" {
   sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-southeast-2"
   continuous_recording          = var.config_continuous_recording ? contains(var.config_continuous_recording_regions, "ap-southeast-2") : false
+  limit_resource_types          = var.config_limit_resource_types
 
   tags = var.tags
 
@@ -248,6 +254,7 @@ module "config_baseline_ca-central-1" {
   sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ca-central-1"
   continuous_recording          = var.config_continuous_recording ? contains(var.config_continuous_recording_regions, "ca-central-1") : false
+  limit_resource_types          = var.config_limit_resource_types
 
   tags = var.tags
 
@@ -270,6 +277,7 @@ module "config_baseline_eu-central-1" {
   sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "eu-central-1"
   continuous_recording          = var.config_continuous_recording ? contains(var.config_continuous_recording_regions, "eu-central-1") : false
+  limit_resource_types          = var.config_limit_resource_types
 
   tags = var.tags
 
@@ -292,6 +300,7 @@ module "config_baseline_eu-north-1" {
   sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "eu-north-1"
   continuous_recording          = var.config_continuous_recording ? contains(var.config_continuous_recording_regions, "eu-north-1") : false
+  limit_resource_types          = var.config_limit_resource_types
 
   tags = var.tags
 
@@ -314,6 +323,7 @@ module "config_baseline_eu-west-1" {
   sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "eu-west-1"
   continuous_recording          = var.config_continuous_recording ? contains(var.config_continuous_recording_regions, "eu-west-1") : false
+  limit_resource_types          = var.config_limit_resource_types
 
   tags = var.tags
 
@@ -336,6 +346,7 @@ module "config_baseline_eu-west-2" {
   sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "eu-west-2"
   continuous_recording          = var.config_continuous_recording ? contains(var.config_continuous_recording_regions, "eu-west-2") : false
+  limit_resource_types          = var.config_limit_resource_types
 
   tags = var.tags
 
@@ -358,6 +369,7 @@ module "config_baseline_eu-west-3" {
   sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "eu-west-3"
   continuous_recording          = var.config_continuous_recording ? contains(var.config_continuous_recording_regions, "eu-west-3") : false
+  limit_resource_types          = var.config_limit_resource_types
 
   tags = var.tags
 
@@ -380,6 +392,7 @@ module "config_baseline_sa-east-1" {
   sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "sa-east-1"
   continuous_recording          = var.config_continuous_recording ? contains(var.config_continuous_recording_regions, "sa-east-1") : false
+  limit_resource_types          = var.config_limit_resource_types
 
   tags = var.tags
 
@@ -402,6 +415,7 @@ module "config_baseline_us-east-1" {
   sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "us-east-1"
   continuous_recording          = var.config_continuous_recording ? contains(var.config_continuous_recording_regions, "us-east-1") : false
+  limit_resource_types          = var.config_limit_resource_types
 
   tags = var.tags
 
@@ -424,6 +438,7 @@ module "config_baseline_us-east-2" {
   sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "us-east-2"
   continuous_recording          = var.config_continuous_recording ? contains(var.config_continuous_recording_regions, "us-east-2") : false
+  limit_resource_types          = var.config_limit_resource_types
 
   tags = var.tags
 
@@ -446,6 +461,7 @@ module "config_baseline_us-west-1" {
   sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "us-west-1"
   continuous_recording          = var.config_continuous_recording ? contains(var.config_continuous_recording_regions, "us-west-1") : false
+  limit_resource_types          = var.config_limit_resource_types
 
   tags = var.tags
 
@@ -468,6 +484,7 @@ module "config_baseline_us-west-2" {
   sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "us-west-2"
   continuous_recording          = var.config_continuous_recording ? contains(var.config_continuous_recording_regions, "us-west-2") : false
+  limit_resource_types          = var.config_limit_resource_types
 
   tags = var.tags
 

--- a/modules/config-baseline/main.tf
+++ b/modules/config-baseline/main.tf
@@ -40,8 +40,12 @@ resource "aws_config_configuration_recorder" "recorder" {
   role_arn = var.iam_role_arn
 
   recording_group {
-    all_supported                 = true
+    all_supported                 = length(var.limit_resource_types) == 0
     include_global_resource_types = var.include_global_resource_types
+    resource_types                = var.limit_resource_types
+    recording_strategy {
+      use_only = length(var.limit_resource_types) == 0 ? "ALL_SUPPORTED_RESOURCE_TYPES" : "INCLUSION_BY_RESOURCE_TYPES"
+    }
   }
 
   recording_mode {

--- a/modules/config-baseline/variables.tf
+++ b/modules/config-baseline/variables.tf
@@ -50,6 +50,12 @@ variable "continuous_recording" {
   default     = true
 }
 
+variable "limit_resource_types" {
+  description = "Only record changes for listed resource types. Records all if empty."
+  type        = list(string)
+  default     = []
+}
+
 variable "include_global_resource_types" {
   description = "Specifies whether AWS Config includes all supported types of global resources with the resources that it records."
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -349,6 +349,12 @@ variable "config_global_resources_all_regions" {
   default     = false
 }
 
+variable "config_limit_resource_types" {
+  description = "Only record changes for listed resource types. Records all if empty."
+  type        = list(string)
+  default     = []
+}
+
 # --------------------------------------------------------------------------------------------------
 # Variables for cloudtrail-baseline module.
 # --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Enable cost optimisations by limiting Config recording only to specific resources (e.g., [those required by Security Hub](https://docs.aws.amazon.com/securityhub/latest/userguide/controls-config-resources.html)).