### PR TITLE
FIX CE-454: Disable global resource types if limited

### DIFF
--- a/modules/config-baseline/main.tf
+++ b/modules/config-baseline/main.tf
@@ -41,7 +41,7 @@ resource "aws_config_configuration_recorder" "recorder" {
 
   recording_group {
     all_supported                 = length(var.limit_resource_types) == 0
-    include_global_resource_types = var.include_global_resource_types
+    include_global_resource_types = length(var.limit_resource_types) == 0 ? var.include_global_resource_types : false
     resource_types                = var.limit_resource_types
     recording_strategy {
       use_only = length(var.limit_resource_types) == 0 ? "ALL_SUPPORTED_RESOURCE_TYPES" : "INCLUSION_BY_RESOURCE_TYPES"


### PR DESCRIPTION
If specific resource types to record are listed, we need to disable [collection of global types](https://docs.aws.amazon.com/config/latest/developerguide/select-resources.html), otherwise we end up with:
```
│ Error: putting ConfigService Configuration Recorder (default): InvalidRecordingGroupException: The recording group provided is not valid
```

Note: we will still collect the global resources we're interested in, as [they're explicitly listed as needed for Security Hub](https://docs.aws.amazon.com/securityhub/latest/userguide/controls-config-resources.html) (e.g., `AWS::IAM::*`).

Fixup for #6.