### PR TITLE
FIX ASH-860: Supply SNS topic name to CloudTrail

### DIFF
--- a/modules/cloudtrail-baseline/main.tf
+++ b/modules/cloudtrail-baseline/main.tf
@@ -284,7 +284,7 @@ resource "aws_cloudtrail" "global" {
   kms_key_id                    = aws_kms_key.cloudtrail.arn
   s3_bucket_name                = var.s3_bucket_name
   s3_key_prefix                 = var.s3_key_prefix
-  sns_topic_name                = var.cloudtrail_sns_topic_enabled ? aws_sns_topic.cloudtrail-sns-topic[0].arn : null
+  sns_topic_name                = var.cloudtrail_sns_topic_enabled ? aws_sns_topic.cloudtrail-sns-topic[0].name : null
 
   event_selector {
     read_write_type           = "All"


### PR DESCRIPTION
The ARN only needs to be supplied if the SNS topic is in a different region (which won't happen since both are created at the same place here), otherwise it causes a perpetual diff:
```hcl
~ sns_topic_name = "cloudtrail-multi-region-sns-topic" -> "arn:aws:sns:${region}:${account}:cloudtrail-multi-region-sns-topic"

```