### PR TITLE
FIX ASH-1815: Block SSE-C encryption on secure-bucket SSE configs

### DIFF
--- a/modules/secure-bucket/main.tf
+++ b/modules/secure-bucket/main.tf
@@ -38,6 +38,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "access_log" {
   bucket = aws_s3_bucket.access_log.id
 
   rule {
+    blocked_encryption_types = ["SSE-C"]
+
     apply_server_side_encryption_by_default {
       sse_algorithm = "AES256"
     }
@@ -99,10 +101,12 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "content" {
   bucket = aws_s3_bucket.content.id
 
   rule {
+    blocked_encryption_types = ["SSE-C"]
+    bucket_key_enabled       = var.bucket_key_enabled
+
     apply_server_side_encryption_by_default {
       sse_algorithm = "AES256"
     }
-    bucket_key_enabled = var.bucket_key_enabled
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds `blocked_encryption_types = ["SSE-C"]` to both `aws_s3_bucket_server_side_encryption_configuration` rules (`access_log` and `content`) in `modules/secure-bucket/main.tf`
- Matches the SSE-C blocking policy already applied to every other shared-module bucket (ASH-1815 / #1725 in `terraform-shared-modules`)
- Fixes persistent drift in `terragrunt-vertice-infra/root/layer-base` where live state has SSE-C blocked but the module code did not, causing Terraform to want to remove the block on every plan

## Test plan

- [ ] Merge this PR and note the new commit SHA
- [ ] Bump the fork ref in `tg-layer-base/secure_baseline.tf` to the new commit
- [ ] Run `plan-tg-module` on `tg-layer-base` and confirm `root/layer-base` reports `No changes` for `module.secure_baseline.module.audit_log_bucket[0].aws_s3_bucket_server_side_encryption_configuration.access_log` and `.content`

Generated with Claude Code