### PR TITLE
FIX ASH-2094: add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+.env


### PR DESCRIPTION
Prevent committing local secrets by ignoring `.env`.

Ref: https://vertice.atlassian.net/browse/ASH-2094